### PR TITLE
Allow passing current user in shopping config

### DIFF
--- a/app/controllers/shopping/api_controller.rb
+++ b/app/controllers/shopping/api_controller.rb
@@ -3,8 +3,8 @@ module Shopping
     include JSONAPI::ActsAsResourceController
     protect_from_forgery with: :null_session
 
-    # def context
-    #   { resource_owner: current_user }
-    # end
+    def context
+      { resource_owner: Shopping.config.current_user_method.call }
+    end
   end
 end

--- a/lib/shopping.rb
+++ b/lib/shopping.rb
@@ -7,4 +7,8 @@ module Shopping
     yield @config if block_given?
     @config
   end
+
+  def self.config
+    @config
+  end
 end

--- a/lib/shopping/config.rb
+++ b/lib/shopping/config.rb
@@ -4,5 +4,9 @@ module Shopping
     def logger(logger=nil)
       @logger ||= logger
     end
+
+    def current_user_method(callable=nil)
+      @current_user ||= callable
+    end
   end
 end

--- a/spec/dummy/config/initializers/shopping.rb
+++ b/spec/dummy/config/initializers/shopping.rb
@@ -1,3 +1,4 @@
 Shopping.configure do |config|
   config.logger Rails.logger
+  config.current_user_method -> { nil }
 end


### PR DESCRIPTION
Adds 'current_user_method' to config, which must be passed a callable object that will return the current user for the request.