### PR TITLE
Feature/canceled state

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.1)
     mustache (1.0.5)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     pg (0.20.0)
     pry (0.10.4)

--- a/app/models/shopping/cart_purchase.rb
+++ b/app/models/shopping/cart_purchase.rb
@@ -1,13 +1,33 @@
 module Shopping
   class CartPurchase < ActiveRecord::Base
+    MUTABLE_PROPERTIES = %w(canceled_at).freeze
+
     extend Shopping::AttributeAccessibleHelper
     belongs_to :cart
 
     validates :cart_id, presence: true
-    validate :unpurchased_cart
+    validate :no_other_successful_purchase
     validate :not_failed
+    validate :can_cancel
+    validate :only_updating_mutable
 
     attr_accessible :cart_id, :succeeded_at, :failed_at, :options
+
+    def canceled?
+      self.canceled_at.present?
+    end
+
+    def failed?
+      self.failed_at.present?
+    end
+
+    def successful?
+      self.succeeded_at.present?
+    end
+
+    def incomplete?
+      self.succeeded_at.nil? && self.failed_at.nil?
+    end
 
     def fail!
       self.update!({failed_at: Time.zone.now})
@@ -31,9 +51,15 @@ module Shopping
 
     private
 
-    def unpurchased_cart
-      if self.cart.present? && Shopping::CartPurchase.where('cart_id=? and succeeded_at is not null', self.cart_id).exists?
-        self.errors.add(:cart, 'must not have a successful cart purchase') 
+    def no_other_successful_purchase
+      if self.new_record? && Shopping::CartPurchase.where('cart_id=? and succeeded_at is not null', self.cart_id).exists?
+        self.errors.add(:cart, 'must not have a successful cart purchase')
+      end
+    end
+
+    def only_updating_mutable
+      if self.persisted? && self.successful? && self.changed_attributes.keys.any?{|k| !MUTABLE_PROPERTIES.include?(k) }
+        self.errors.add(:succeeded_at, 'only mutable properties may be changed on a successful cart purchase')
       end
     end
 
@@ -42,6 +68,13 @@ module Shopping
         self.errors.add(:failed_at, 'cannot update failed cart purchase')
       end
     end
-    
+
+    def can_cancel
+      if self.changed_attributes.keys.include?("canceled_at")
+        if !self.successful? || !self.changed_attributes["canceled_at"].nil?
+          self.errors.add(:canceled_at, 'only successful, uncanceled cart purchases may be canceled')
+        end
+      end
+    end
   end
 end

--- a/app/resources/shopping/cart_purchase_resource.rb
+++ b/app/resources/shopping/cart_purchase_resource.rb
@@ -2,7 +2,7 @@ module Shopping
   class CartPurchaseResource < JSONAPI::Resource
     model_name 'Shopping::CartPurchase'
 
-    attributes :cart_id, :created_at, :succeeded_at, :failed_at, :options
+    attributes :cart_id, :created_at, :succeeded_at, :failed_at, :canceled_at, :options
     has_one :cart
 
     def source_model

--- a/app/resources/shopping/cart_resource.rb
+++ b/app/resources/shopping/cart_resource.rb
@@ -7,15 +7,17 @@ module Shopping
     has_many :cart_purchases
 
     filters :user_id, :origin
-    
+
     filter :state, apply: ->(records, value, _options){
       case value[0]
       when 'purchased'
-        records.where('purchased_at IS NOT NULL')
+        records.purchased
       when 'failed'
-        records.where(purchased_at: nil).where.not(failed_at: nil)
+        records.failed
       when 'open'
-        records.where(purchased_at: nil, failed_at: nil)
+        records.open
+      when 'canceled'
+        records.canceled
       end
     }
 

--- a/db/migrate/20180423170427_add_canceled_at_to_shopping_cart_purchases.rb
+++ b/db/migrate/20180423170427_add_canceled_at_to_shopping_cart_purchases.rb
@@ -1,0 +1,5 @@
+class AddCanceledAtToShoppingCartPurchases < ActiveRecord::Migration
+  def change
+    add_column :shopping_cart_purchases, :canceled_at, :timestamp
+  end
+end

--- a/spec/acceptance/cart_purchases_controller_spec.rb
+++ b/spec/acceptance/cart_purchases_controller_spec.rb
@@ -31,6 +31,7 @@ resource 'CartPurchase', type: :acceptance do
            :created_at=>"#{cart_purchase.created_at.as_json}",
            :succeeded_at=>nil,
            :failed_at=>nil,
+           :canceled_at=>nil,
            :options=>{}},
          :relationships=>
           {:cart=>
@@ -86,6 +87,7 @@ resource 'CartPurchase', type: :acceptance do
            "created_at"=>cp.created_at.as_json,
            "succeeded_at"=>nil,
            "failed_at"=>nil,
+           "canceled_at"=>nil,
            "options" => {}},
          "relationships"=>
           {"cart"=>

--- a/spec/acceptance/carts_controller_spec.rb
+++ b/spec/acceptance/carts_controller_spec.rb
@@ -182,7 +182,7 @@ resource 'Cart', type: :acceptance do
       cart.failed_at = Time.zone.now
       cart.save
       cart2 = create(:cart, user_id: cart.user_id, failed_at: Time.zone.now, purchased_at: Time.zone.now)
-      
+
       expected_response = {:data=>
         [{:id=>"#{cart.id}",
           :type=>"carts",
@@ -222,7 +222,7 @@ resource 'Cart', type: :acceptance do
 
     example 'with a logged in user with open carts' do
       cart2 = create(:cart, user_id: cart.user_id, failed_at: Time.zone.now, purchased_at: Time.zone.now)
-      
+
       expected_response = {:data=>
         [{:id=>"#{cart.id}",
           :type=>"carts",
@@ -257,17 +257,50 @@ resource 'Cart', type: :acceptance do
 
   end
 
-  get '/carts?filter[state]=failed', document: true do
+  get '/carts?filter[state]=canceled', document: true do
     parameter :state, 'State', required: true
+
+    example 'with a logged in user with canceled carts' do
+      cart2 = create(:cart, user_id: cart.user_id, purchased_at: Time.zone.now)
+      create(:cart_purchase, cart_id: cart.id, succeeded_at: Time.zone.now, canceled_at: Time.zone.now)
+      cart.purchased_at = Time.zone.now
+      cart.save
+
+      expected_response = {:data=>
+        [{:id=>"#{cart.id}",
+          :type=>"carts",
+          :links=>{:self=>"http://example.org/carts/#{cart.id}"},
+          :attributes=>
+           {:user_id=>cart.user_id,
+            :purchased_at=>cart.purchased_at.as_json,
+            :created_at=>cart.created_at.as_json,
+            :updated_at=>cart.updated_at.as_json,
+            :origin=>nil},
+          :relationships=>
+           {:line_items=>
+             {:links=>
+               {:self=>"http://example.org/carts/#{cart.id}/relationships/line_items",
+                :related=>"http://example.org/carts/#{cart.id}/line_items"}},
+            :cart_purchases=>
+             {:links=>
+               {:self=>"http://example.org/carts/#{cart.id}/relationships/cart_purchases",
+                :related=>"http://example.org/carts/#{cart.id}/cart_purchases"}}}}]}
+
+      log_in_user(cart.user_id)
+      do_request
+
+      expect(status).to be 200
+      expect(response_json).to eq(expected_response)
+    end
+
+    example 'with a logged out user' do
+      do_request
+      expect(status).to be(403)
+    end
 
   end
 
-  get '/carts?filter[state]=open', document: true do
-    parameter :state, 'State', required: true
-
-  end
-
-  get '/carts?filter[origin]=:origin', document: true do 
+  get '/carts?filter[origin]=:origin', document: true do
     parameter :origin, 'Origin', required: true
     let(:origin){ 'origin' }
 
@@ -361,10 +394,10 @@ resource 'Cart', type: :acceptance do
 
     example 'logged in user with mismatched user_id' do
       expected_error = {:errors=>[{:title=>"Index Forbidden", :detail=>"You don't have permission to index this shopping/cart.", :code=>"403", :status=>"403"}]}
-      
+
       log_in_user(cart.user_id + 1)
       do_request
-      
+
       expect(status).to be 403
       expect(response_json).to eq(expected_error)
     end
@@ -535,7 +568,7 @@ resource 'Cart', type: :acceptance do
     }
 
     example 'Update user id of unowned cart with no logged in user' do
-      expected = 
+      expected =
         {:errors=>
           [{:title=>"Update Forbidden",
             :detail=>"You don't have permission to update this shopping/cart.",

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180123145617) do
+ActiveRecord::Schema.define(version: 20180423170427) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 20180123145617) do
     t.datetime "created_at",                null: false
     t.datetime "updated_at",                null: false
     t.jsonb    "options",      default: {}, null: false
+    t.datetime "canceled_at"
   end
 
   create_table "shopping_carts", force: :cascade do |t|

--- a/spec/models/shopping/cart_purchase_spec.rb
+++ b/spec/models/shopping/cart_purchase_spec.rb
@@ -7,18 +7,18 @@ module Shopping
     let(:cart_purchase){ build(:cart_purchase, cart_id: cart.id) }
 
     describe "cart" do
-    
+
       it "must be present" do
         cart_purchase.cart_id = nil
         expect{cart_purchase.save!}.to raise_error(ActiveRecord::RecordInvalid)
       end
-    
+
       it "must not have any successful cart purchases at time of creation" do
         create(:cart_purchase, cart_id: cart.id, succeeded_at: Time.zone.now)
         cart.update!({purchased_at: Time.zone.now})
         expect{cart_purchase.save!}.to raise_error(ActiveRecord::RecordInvalid)
       end
-    
+
     end
 
     describe "succeeded_at" do
@@ -27,13 +27,26 @@ module Shopping
       it "locks the cart purchase when set" do
         expect{cart_purchase.update!({failed_at: Time.zone.now})}.to raise_error(ActiveRecord::RecordInvalid)
       end
-      
+
       it "prevents the creation of other cart purchases on the cart when set" do
         expect{create(:cart_purchase, cart_id: cart_purchase.cart_id)}.to raise_error(ActiveRecord::RecordInvalid)
       end
 
     end
-    
+
+    describe "canceled_at" do
+      it "can't be set on an unsuccessful cart purchase" do
+        cart_purchase.canceled_at = Time.zone.now
+        expect{cart_purchase.save!}.to raise_error(ActiveRecord::RecordInvalid)
+      end
+
+      it "can be set on a successful cart purchase" do
+        cart_purchase.succeeded_at = Time.zone.now
+        cart_purchase.save!
+        expect{cart_purchase.update!(canceled_at: Time.zone.now)}.to_not raise_error
+      end
+    end
+
     describe "failed_at" do
       let(:cart_purchase){ create(:cart_purchase, cart_id: cart.id, failed_at: Time.zone.now )}
       it "locks the cart purchase when set" do

--- a/spec/models/shopping/cart_spec.rb
+++ b/spec/models/shopping/cart_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 module Shopping
   RSpec.describe Cart, type: :model do
     let(:cart){ create(:cart) }
-    
+
     describe "lock!" do
 
       it "sets the locked_at property of the cart" do
@@ -17,7 +17,7 @@ module Shopping
 
       context "when the cart has been purchased" do
         before{ cart.update!({purchased_at: Time.zone.now })}
-        
+
         it "raises an error" do
           expect{ cart.lock! }.to raise_error(ActiveRecord::RecordInvalid)
         end
@@ -33,10 +33,30 @@ module Shopping
 
       context "when the cart has been purchased" do
         before{ cart.update!({purchased_at: Time.zone.now })}
-        
+
         it "raises an error" do
           expect{ cart.reload.unlock! }.to raise_error(ActiveRecord::RecordInvalid)
         end
+      end
+    end
+
+    describe "#canceled?" do
+      it "returns true if the cart has any canceled purchases" do
+        create(:cart_purchase, cart_id: cart.id, succeeded_at: Time.zone.now, canceled_at: Time.zone.now)
+        expect(cart).to be_canceled
+      end
+    end
+
+    describe ".canceled" do
+      it "only returns canceled carts" do
+        cart_2 = create(:cart)
+        create(:cart_purchase, cart_id: cart_2.id, failed_at: Time.zone.now)
+        create(:cart_purchase, cart_id: cart_2.id, succeeded_at: Time.zone.now, canceled_at: Time.zone.now)
+
+        carts = Shopping::Cart.canceled
+
+        expect(carts).to include(cart_2)
+        expect(carts).to_not include(cart)
       end
     end
 


### PR DESCRIPTION
Adds `canceled_at` attribute to cart purchases, which can only be set on a successful cart purchase. Also adds helpful scopes to carts and cart purchases, and specs for new behavior.

https://app.clubhouse.io/bark/story/17181/add-canceled-at-to-cart-purchases