### PR TITLE
Fix bug in update line item

### DIFF
--- a/app/services/shopping/update_line_item_service.rb
+++ b/app/services/shopping/update_line_item_service.rb
@@ -31,7 +31,7 @@ module Shopping
     end
 
     def update!
-      line_item = @cart.line_items.find_by!(source_id: @source.id, source_type: @source.type, sale_price: @source.price)
+      line_item = @cart.line_items.find_by!(source_id: @source.id, source_type: @source.class.name, sale_price: @source.price)
       line_item.quantity = @quantity
       original_options = line_item.options || {}
       line_item.options = original_options.merge(options)


### PR DESCRIPTION
Type should refer directly to the class name of the source object, not to a `type` method. Was breaking for line items whose sources were `Plan` objects 

CH: https://app.shortcut.com/bark/story/671263/fix-bug-in-shopping-gem